### PR TITLE
Support implementations calling themselves

### DIFF
--- a/test/protomock_test.exs
+++ b/test/protomock_test.exs
@@ -231,6 +231,18 @@ defmodule ProtoMockTest do
 
       assert Calculator.add(protomock, 1, 2) == :second
     end
+
+    test "allows recursive calls" do
+      protomock = ProtoMock.new()
+
+      protomock
+      |> ProtoMock.stub(&Calculator.add/3, fn
+        1, 2 -> {:first, Calculator.add(protomock, 3, 4)}
+        3, 4 -> :second
+      end)
+
+      assert Calculator.add(protomock, 1, 2) == {:first, :second}
+    end
   end
 
   defp mock_add() do


### PR DESCRIPTION
Specifically ran into a case where a stream is produced that calls a fake function in a lazy case, and then made into a list in a subsequent call:

```elixir
stream = [1, 2, 3]
         |> Stream.map(fn x -> Calculator.add(protomock, x, 1) end)
Calculator.write_out(protomock, stream)

# where Calculator.write_out/2 implementation does something like:

stream |> Enum.into([])
```