### PR TITLE
Use ~r sigil instead of deprecated ~R

### DIFF
--- a/lib/protomock.ex
+++ b/lib/protomock.ex
@@ -4,10 +4,10 @@ defmodule ProtoMock do
   @moduledoc "README.md"
              |> File.read!()
              |> String.split("<!-- MDOC -->")
-             |> Enum.filter(&(&1 =~ ~R{<!\-\-\ INCLUDE\ \-\->}))
+             |> Enum.filter(&(&1 =~ ~r{<!\-\-\ INCLUDE\ \-\->}))
              |> Enum.join("\n")
              # compensate for anchor id differences between ExDoc and GitHub
-             |> (&Regex.replace(~R{\(\#\K(?=[a-z][a-z0-9-]+\))}, &1, "module-")).()
+             |> (&Regex.replace(~r{\(\#\K(?=[a-z][a-z0-9-]+\))}, &1, "module-")).()
 
   use GenServer
 


### PR DESCRIPTION
tests still pass, and the README still renders ok to me as the Protomock moduledoc locally.

See https://github.com/elixir-lang/elixir/blob/v1.16/CHANGELOG.md#elixir-7 for deprecation description